### PR TITLE
Simplify DOM changes for nickname using `::after`

### DIFF
--- a/hn-friends/src/hn-friends.js
+++ b/hn-friends/src/hn-friends.js
@@ -7,7 +7,7 @@ css(`
     padding: 0.25em;
   }
 
-  .friends.tagged::after {
+  .hnuser[title]::after {
     background: url("${chrome.extension.getURL("img/tag.svg")}") no-repeat 0 0 / 1em 0.75em;
     content: "";
     display: inline-block;
@@ -29,7 +29,6 @@ css(`
     }
     if (username in tags) {
       user.title = tags[username];
-      user.classList.add("tagged");
     }
   }
 })();

--- a/hn-friends/src/hn-friends.js
+++ b/hn-friends/src/hn-friends.js
@@ -7,19 +7,16 @@ css(`
     padding: 0.25em;
   }
 
-  .tag {
-    height: 0.75em;
+  .friends.tagged::after {
+    background: url("${chrome.extension.getURL("img/tag.svg")}") no-repeat 0 0 / 1em 0.75em;
+    content: "";
+    display: inline-block;
+    height: 1em;
+    margin-inline-start: 0.25em;
+    vertical-align: middle;
+    width: 1em;
   }
 `);
-
-function addTagElement(user, tag) {
-  const img = document.createElement('img');
-  img.src = chrome.extension.getURL('img/tag.svg');
-  img.className = 'tag';
-  img.title = tag;
-  user.parentElement.insertBefore(img, user.nextSibling);
-  user.parentElement.insertBefore(document.createTextNode(' '), img);
-}
 
 (async () => {
   const { friends, tags } = await data;
@@ -32,7 +29,7 @@ function addTagElement(user, tag) {
     }
     if (username in tags) {
       user.title = tags[username];
-      addTagElement(user, tags[username]);
+      user.classList.add("tagged");
     }
   }
 })();


### PR DESCRIPTION
I'd check this before merging, since I only tested it by live editing a page. Mainly the syntax for interpolating the image URI. Worst case, you can embed it in the stylesheet as a `data:image/svg+xml` URI.

Changes for end user:
- Label icon is now inside orange box
- (This one's just for me, frankly) More consistent number of children in each `span.subline` of post lists (e.g. the main page)